### PR TITLE
Redirecting /api/ to our backend

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,17 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  rewrites: async () => {
+    return [
+      {
+        source: "/api/:path*",
+        destination:
+          process.env.NODE_ENV === "development"
+            ? "http://127.0.0.1:8000/:path*"
+            : "https://api.meet-sync.us/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
- `next.config.ts` updated to redirect `/api/` requests to our backend. in local/dev, it will redirect to `localhost:8000`. in prod it will redirect to our gcp instance

- usage: when making any calls to the backend, simply make the call to `/api/<your-endpoint-here>/`